### PR TITLE
Add newline to success output of `add`

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -27,7 +27,7 @@ func NewAdd(c *Cmd) *cobra.Command {
 				os.Exit(1)
 			}
 
-			cmd.Printf("Successfully added `%s=%s` to `%s` profile.", key, value, profile)
+			cmd.Printf("Successfully added `%s=%s` to `%s` profile.\n", key, value, profile)
 		},
 	}
 }


### PR DESCRIPTION
Tiny PR because I noticed the newline was missing which screwed up my prompt :P