### PR TITLE
Missing newlines in "use" and "current" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOBIN ?= $(shell go env GOPATH)/bin
 PKG = github.com/dotzero/git-profile
 BIN := git-profile
 
-VERSION := 1.4.0
+VERSION := 1.5.0
 HASH := $(shell git rev-parse --short HEAD)
 DATE := $(shell date +%FT%T%z)
 

--- a/cmd/current.go
+++ b/cmd/current.go
@@ -25,11 +25,11 @@ func Current(cfg storage, v vcs) *cobra.Command {
 
 			res, err := v.Get(currentProfileKey)
 			if len(res) == 0 || err != nil {
-				cmd.Print(defaultProfileName)
+				cmd.Printf("%s\n", defaultProfileName)
 				os.Exit(0)
 			}
 
-			cmd.Printf("%s", res)
+			cmd.Printf("%s\n", res)
 		},
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ func New() *Cmd {
 		CommitHash:  "Unknown",
 		CompileDate: "Unknown",
 		config:      config.New(),
-		git:         &git.Git{},
+		git:         git.New(),
 	}
 }
 

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -43,7 +43,7 @@ func Use(cfg storage, v vcs) *cobra.Command {
 				}
 			}
 
-			cmd.Printf("Successfully applied `%s` profile to current git repository.", profile)
+			cmd.Printf("Successfully applied `%s` profile to current git repository.\n", profile)
 		},
 	}
 }


### PR DESCRIPTION
When using the "use" and "current" command the prompt does not add an ending new-line. As a result follow-up commands are not aligned properly:

Current situation:
```
user@localhost:~$ git-profile current
defaultuser@localhost:~$ git-profile use default
Successfully applied `default` profile to current git repository.user@localhost:~$
```

Expected result:
```
user@localhost:~$ git-profile current
default
user@localhost:~$ git-profile use default
Successfully applied `default` profile to current git repository.
user@localhost:~$
``` 